### PR TITLE
Add a button of project deletion

### DIFF
--- a/src/App/component/ProjectAvatar.jsx
+++ b/src/App/component/ProjectAvatar.jsx
@@ -48,7 +48,7 @@ function ProjectAvatar(props) {
   const [wantedRepoType, setWantedRepoType] = useState("")
   const [hasGithubRepo, setHasGithubRepo] = useState(false)
   const [hasSonarRepo, setHasSonarRepo] = useState(false)
-  const [deletionAlert, setDeletionAlert] = useState(false)
+  const [deletionAlertDialog, setDeletionAlertDialog] = useState(false)
   const jwtToken = localStorage.getItem("jwtToken")
 
   useEffect(() => {
@@ -90,19 +90,15 @@ function ProjectAvatar(props) {
     setAddRepoDialogOpen(true)
   }
 
-  const openDeletionAlert = () => {
-    setDeletionAlert(true)
-  }
-
-  const closeDeletionAlert = () => {
-    setDeletionAlert(false)
+  const toggleDeletionAlertDialog = () => {
+    setDeletionAlertDialog(!deletionAlertDialog)
   }
 
   const deleteProject = () => {
     Axios.post(`http://localhost:9100/pvs-api/project/remove/${props.project.projectId}`, "",
       {headers: {"Authorization": `${jwtToken}`}})
       .then(() => {
-        closeDeletionAlert()
+        toggleDeletionAlertDialog()
         props.reloadProjects()
       })
       .catch((e) => {
@@ -115,11 +111,11 @@ function ProjectAvatar(props) {
     <div>
       <Box className={props.size === 'large' ? classes.large : classes.small}>
       {props.size === 'large' &&
-      <Button onClick={openDeletionAlert}>X</Button>
+      <Button onClick={toggleDeletionAlertDialog}>X</Button>
       }
       <Dialog
-      open={deletionAlert}
-      onClose={closeDeletionAlert}
+      open={deletionAlertDialog}
+      onClose={toggleDeletionAlertDialog}
       aria-labelledby="alert-dialog-title"
       aria-describedby="alert-dialog-description">
         <DialogTitle id="alert-dialog-title">
@@ -131,7 +127,7 @@ function ProjectAvatar(props) {
           </DialogContentText>
         </DialogContent>
         <DialogActions>
-          <Button onClick={closeDeletionAlert}>Back</Button>
+          <Button onClick={toggleDeletionAlertDialog}>Back</Button>
           <Button onClick={deleteProject} autoFocus>
             Delete
           </Button>

--- a/src/App/component/ProjectAvatar.jsx
+++ b/src/App/component/ProjectAvatar.jsx
@@ -49,7 +49,7 @@ function ProjectAvatar(props) {
   const [hasGithubRepo, setHasGithubRepo] = useState(false)
   const [hasSonarRepo, setHasSonarRepo] = useState(false)
   const [deletionAlertDialog, setDeletionAlertDialog] = useState(false)
-  const jwtToken = localStorage.getItem("jwtToken")
+  const jwt = localStorage.getItem("jwtToken")
 
   useEffect(() => {
     if (props.size === 'large') {
@@ -96,7 +96,7 @@ function ProjectAvatar(props) {
 
   const deleteProject = () => {
     Axios.post(`http://localhost:9100/pvs-api/project/remove/${props.project.projectId}`, "",
-      {headers: {"Authorization": `${jwtToken}`}})
+      {headers: {...(jwt && {"Authorization": jwt})}})  // If jwt is null, it will return {} to headers. Otherwise it will return {"Authorization": jwt}
       .then(() => {
         toggleDeletionAlertDialog()
         props.reloadProjects()
@@ -123,7 +123,7 @@ function ProjectAvatar(props) {
         </DialogTitle>
         <DialogContent>
           <DialogContentText id="alert-dialog-description">
-            You can restore it after deleting.
+            You cannot restore it after deleting.
           </DialogContentText>
         </DialogContent>
         <DialogActions>

--- a/src/App/component/ProjectAvatar.jsx
+++ b/src/App/component/ProjectAvatar.jsx
@@ -123,7 +123,7 @@ function ProjectAvatar(props) {
         </DialogTitle>
         <DialogContent>
           <DialogContentText id="alert-dialog-description">
-            If you delete the project, you cannot restore it.
+            You can restore it after deleting.
           </DialogContentText>
         </DialogContent>
         <DialogActions>

--- a/src/App/component/ProjectAvatar.jsx
+++ b/src/App/component/ProjectAvatar.jsx
@@ -8,6 +8,7 @@ import AddIcon from '@material-ui/icons/Add';
 import AddRepositoryDialog from './AddRepositoryDialog';
 import {connect} from 'react-redux'
 import {setCurrentProjectId} from '../../redux/action'
+import Axios from 'axios'
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -83,6 +84,9 @@ function ProjectAvatar(props) {
     <div>
       <Box className={props.size === 'large' ? classes.large : classes.small}>
         <CardActionArea onClick={goToDashboard}>
+        {props.size === 'large' &&
+        <button>X</button>
+        }
           <Avatar alt="first repository" src={props.project.avatarURL} className={classes.avatar}/>
           {props.size === 'large' &&
           <p style={{"textAlign": "center"}}>{props.project.projectName}</p>

--- a/src/App/component/ProjectAvatar.jsx
+++ b/src/App/component/ProjectAvatar.jsx
@@ -95,14 +95,13 @@ function ProjectAvatar(props) {
   }
 
   const deleteProject = () => {
-    Axios.post(`http://localhost:9100/pvs-api/project/remove/${props.project.projectId}`, "",
+    Axios.delete(`http://localhost:9100/pvs-api/project/remove/${props.project.projectId}`,
       {headers: {...(jwt && {"Authorization": jwt})}})  // If jwt is null, it will return {} to headers. Otherwise it will return {"Authorization": jwt}
       .then(() => {
         toggleDeletionAlertDialog()
         props.reloadProjects()
       })
       .catch((e) => {
-        alert(e.response.status)
         console.error(e)
       })
   }

--- a/src/App/component/ProjectAvatar.jsx
+++ b/src/App/component/ProjectAvatar.jsx
@@ -8,7 +8,15 @@ import AddIcon from '@material-ui/icons/Add';
 import AddRepositoryDialog from './AddRepositoryDialog';
 import {connect} from 'react-redux'
 import {setCurrentProjectId} from '../../redux/action'
-import Axios from 'axios'
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle
+} from '@material-ui/core'
+import Axios from "axios"
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -40,6 +48,8 @@ function ProjectAvatar(props) {
   const [wantedRepoType, setWantedRepoType] = useState("")
   const [hasGithubRepo, setHasGithubRepo] = useState(false)
   const [hasSonarRepo, setHasSonarRepo] = useState(false)
+  const [deletionAlert, setDeletionAlert] = useState(false)
+  const jwtToken = localStorage.getItem("jwtToken")
 
   useEffect(() => {
     if (props.size === 'large') {
@@ -80,13 +90,54 @@ function ProjectAvatar(props) {
     setAddRepoDialogOpen(true)
   }
 
+  const openDeletionAlert = () => {
+    setDeletionAlert(true)
+  }
+
+  const closeDeletionAlert = () => {
+    setDeletionAlert(false)
+  }
+
+  const deleteProject = () => {
+    Axios.post(`http://localhost:9100/pvs-api/project/remove/${props.project.projectId}`, "",
+      {headers: {"Authorization": `${jwtToken}`}})
+      .then(() => {
+        closeDeletionAlert()
+        props.reloadProjects()
+      })
+      .catch((e) => {
+        alert(e.response.status)
+        console.error(e)
+      })
+  }
+
   return (
     <div>
       <Box className={props.size === 'large' ? classes.large : classes.small}>
+      {props.size === 'large' &&
+      <Button onClick={openDeletionAlert}>X</Button>
+      }
+      <Dialog
+      open={deletionAlert}
+      onClose={closeDeletionAlert}
+      aria-labelledby="alert-dialog-title"
+      aria-describedby="alert-dialog-description">
+        <DialogTitle id="alert-dialog-title">
+          {"Are You Sure You Want to Delete This Project?"}
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText id="alert-dialog-description">
+            If you delete the project, you cannot restore it.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={closeDeletionAlert}>Back</Button>
+          <Button onClick={deleteProject} autoFocus>
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
         <CardActionArea onClick={goToDashboard}>
-        {props.size === 'large' &&
-        <button>X</button>
-        }
           <Avatar alt="first repository" src={props.project.avatarURL} className={classes.avatar}/>
           {props.size === 'large' &&
           <p style={{"textAlign": "center"}}>{props.project.projectName}</p>

--- a/src/App/component/SelectProject.jsx
+++ b/src/App/component/SelectProject.jsx
@@ -42,7 +42,7 @@ function SelectProject({setCurrentProjectId}) {
   const jwtToken = localStorage.getItem("jwtToken")
 
   const loadProjects = () => {
-    Axios.get("http://localhost:9100/pvs-api/project/1",
+    Axios.get("http://localhost:9100/pvs-api/project/1/active",
       {headers: {"Authorization": `${jwtToken}`}})
       .then((response) => {
         setProjects(response.data)

--- a/src/App/component/SelectProject.jsx
+++ b/src/App/component/SelectProject.jsx
@@ -40,9 +40,10 @@ function SelectProject({setCurrentProjectId}) {
   const [addRepoDialogOpen, setAddRepoDialogOpen] = useState(false)
   const [projects, setProjects] = useState([])
   const jwtToken = localStorage.getItem("jwtToken")
+  const memberId = 1 // There are no other members yet.
 
   const loadProjects = () => {
-    Axios.get("http://localhost:9100/pvs-api/project/1/active",
+    Axios.get(`http://localhost:9100/pvs-api/project/${memberId}/active`,
       {headers: {"Authorization": `${jwtToken}`}})
       .then((response) => {
         setProjects(response.data)


### PR DESCRIPTION
In ProjectAvatar, I create two items: delete button and deletion alert dialog. Now we can delete projects in the select project page normally. There are still something able to refactor. For instance, separating the alert dialog, using patch request, etc.

In SelectProject, I modify the request to hide the removed project.

You should review this PR with another PR in backend, Project Entity Deletion.