### PR TITLE
Adjust add repo field to use the radio button to select the repo type

### DIFF
--- a/src/App/component/AddProjectDialog.jsx
+++ b/src/App/component/AddProjectDialog.jsx
@@ -15,7 +15,7 @@ export default function AddProjectDialog({open, reloadProjects, handleClose}) {
   const [projectName, setProjectName] = useState("")
   const jwtToken = localStorage.getItem("jwtToken")
 
-  const createProject = () => {
+  const createProject = async () => {
     if (projectName.trim() === "") {
       alert("不準啦馬的>///<")
       return
@@ -34,7 +34,7 @@ export default function AddProjectDialog({open, reloadProjects, handleClose}) {
     }
 
     try {
-      Axios.post("http://localhost:9100/pvs-api/project", payload, config)
+      await Axios.post("http://localhost:9100/pvs-api/project", payload, config)
     } catch (e) {
       alert(e?.response?.status)
       console.error(e)

--- a/src/App/component/AddProjectDialog.jsx
+++ b/src/App/component/AddProjectDialog.jsx
@@ -1,7 +1,5 @@
 import {useEffect, useState} from 'react'
 import Axios from 'axios'
-import InputAdornment from '@material-ui/core/InputAdornment';
-import {SiGithub, SiSonarqube} from 'react-icons/si'
 
 import {
   Button,
@@ -15,90 +13,49 @@ import {
 
 export default function AddProjectDialog({open, reloadProjects, handleClose}) {
   const [projectName, setProjectName] = useState("")
-  const [githubRepositoryURL, setGithubRepositoryURL] = useState("")
-  const [sonarRepositoryURL, setSonarRepositoryURL] = useState("")
-  const setIsGithubAvailable = useState(false)[1]
-  const setIsSonarAvailable = useState(false)[1]
   const jwtToken = localStorage.getItem("jwtToken")
 
   const createProject = () => {
-    let checker = []
-    if (projectName === "" || (githubRepositoryURL === "" && sonarRepositoryURL === "")) {
+    if (projectName.trim() === "") {
       alert("不準啦馬的>///<")
-    } else {
-      if (githubRepositoryURL !== "") {
-        checker.push(checkGithubRepositoryURL());
-      }
-      if (sonarRepositoryURL !== "") {
-        checker.push(checkSonarRepositoryURL());
-      }
-
-      Promise.all(checker)
-        .then((response) => {
-          if (response.includes(false) === false) {
-            let payload = {
-              projectName: projectName,
-              githubRepositoryURL: githubRepositoryURL,
-              sonarRepositoryURL: sonarRepositoryURL
-            }
-
-            Axios.post("http://localhost:9100/pvs-api/project", payload,
-              {headers: {"Authorization": `${jwtToken}`}})
-              .then(() => {
-                reloadProjects()
-                handleClose()
-              })
-              .catch((e) => {
-                alert(e.response.status)
-                console.error(e)
-              })
-          }
-        }).catch((e) => {
-        alert(e.response.status)
-        console.error(e)
-      })
+      return
     }
+
+    const payload = {
+      projectName,
+      githubRepositoryURL: "",
+      sonarRepositoryURL: ""
+    } // 傳空的repository
+
+    const config = {
+      headers: {
+        ...(jwtToken && {"Authorization": jwtToken})
+      }
+    }
+
+    try {
+      Axios.post("http://localhost:9100/pvs-api/project", payload, config)
+    } catch (e) {
+      alert(e?.response?.status)
+      console.error(e)
+    } // 回傳給後端
+
+    reloadProjects()
+    handleClose()
   }
 
-  const checkGithubRepositoryURL = () => {
-    return Axios.get(`http://localhost:9100/pvs-api/repository/github/check?url=${githubRepositoryURL}`,
-      {headers: {"Authorization": `${jwtToken}`}})
-      .then(() => {
-        setIsGithubAvailable(true);
-        return true
-      })
-      .catch(() => {
-        alert("github error")
-        return false
-      })
-  }
-
-  const checkSonarRepositoryURL = () => {
-    return Axios.get(`http://localhost:9100/pvs-api/repository/sonar/check?url=${sonarRepositoryURL}`,
-      {headers: {"Authorization": `${jwtToken}`}})
-      .then(() => {
-        setIsSonarAvailable(true);
-        return true
-      })
-      .catch((e) => {
-        alert("sonar error")
-        console.error(e)
-        return false
-      })
-  }
-
+  // 刷新
   useEffect(() => {
     setProjectName("")
-    setGithubRepositoryURL("")
-    setSonarRepositoryURL("")
   }, [open])
 
+  // dialog 介面
   return (
     <Dialog open={open} onClose={handleClose} aria-labelledby="form-dialog-title">
       <DialogTitle id="form-dialog-title">Create Project</DialogTitle>
       <DialogContent>
         <DialogContentText>
-          To create a project, please enter the project name and the repository URL you want to subscribe here.
+          To create a project, please enter the project name.
         </DialogContentText>
         <TextField
           autoFocus
@@ -109,43 +66,6 @@ export default function AddProjectDialog({open, reloadProjects, handleClose}) {
           fullWidth
           onChange={(e) => {
             setProjectName(e.target.value)
-          }}
-        />
-        <TextField
-          margin="dense"
-          id="GithubRepositoryURL"
-          label="Github Repository URL"
-          type="text"
-          fullWidth
-          onChange={(e) => {
-            setGithubRepositoryURL(e.target.value)
-          }}
-          required
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                <SiGithub/>
-              </InputAdornment>
-            ),
-          }}
-        />
-
-        <TextField
-          margin="dense"
-          id="SonarRepositoryURL"
-          label="Sonar Repository URL"
-          type="text"
-          fullWidth
-          onChange={(e) => {
-            setSonarRepositoryURL(e.target.value)
-          }}
-          required
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                <SiSonarqube/>
-              </InputAdornment>
-            ),
           }}
         />
       </DialogContent>

--- a/src/App/component/AddRepositoryDialog.jsx
+++ b/src/App/component/AddRepositoryDialog.jsx
@@ -12,8 +12,6 @@ import {
 
 import InputAdornment from '@material-ui/core/InputAdornment';
 import {SiGithub, SiSonarqube, SiGitlab} from 'react-icons/si'
-import {RiAccountCircleFill} from 'react-icons/ri'
-import {GiToken} from 'react-icons/gi'
 
 export default function AddRepositoryDialog({open, reloadProjects, handleClose, projectId, addSonarAvailable}) {
   const [repositoryURL, setRepositoryURL] = useState("")
@@ -44,7 +42,7 @@ export default function AddRepositoryDialog({open, reloadProjects, handleClose, 
       }
       if (sonarRepositoryURL !== "") {
         checker.push(checkSonarRepositoryURL());
-        checker.push(addSonarAvailable);
+        checker.push(addSonarAvailable());
       }
 
       Promise.all(checker)

--- a/src/App/component/AddRepositoryDialog.jsx
+++ b/src/App/component/AddRepositoryDialog.jsx
@@ -42,7 +42,7 @@ export default function AddRepositoryDialog({open, reloadProjects, handleClose, 
       }
       if (sonarRepositoryURL !== "") {
         checker.push(checkSonarRepositoryURL());
-        checker.push(addSonarAvailable());
+        checker.push(checkAddSonarAvailable());
       }
 
       Promise.all(checker)

--- a/src/App/component/AddRepositoryDialog.jsx
+++ b/src/App/component/AddRepositoryDialog.jsx
@@ -10,33 +10,263 @@ import {
   TextField
 } from '@material-ui/core'
 
+import InputAdornment from '@material-ui/core/InputAdornment';
+import {SiGithub, SiSonarqube, SiGitlab} from 'react-icons/si'
+import {RiAccountCircleFill} from 'react-icons/ri'
+import {GiToken} from 'react-icons/gi'
+
 export default function AddRepositoryDialog({open, reloadProjects, handleClose, projectId, repoType}) {
   const [repositoryURL, setRepositoryURL] = useState("")
+  const [githubRepositoryURL, setGithubRepositoryURL] = useState("")
+  const [gitlabRepositoryURL, setGitlabRepositoryURL] = useState("")
+  const [sonarRepositoryURL, setSonarRepositoryURL] = useState("")
+  const setIsGithubAvailable = useState(false)[1]
+  const setIsGitlabAvailable = useState(false)[1]
+  const setIsSonarAvailable = useState(false)[1]
   const jwtToken = localStorage.getItem("jwtToken")
 
+  const [showGithubDiv, setShowGithubDiv] = useState(false)
+  const [showGitlabDiv, setShowGitlabDiv] = useState(false)
+  const [showSonarDiv, setShowSonarDiv] = useState(false)
+
   const addRepository = () => {
-    if (repositoryURL === "") {
+    let checker = []
+    if (repositoryURL === "" && (githubRepositoryURL === "" && sonarRepositoryURL === "" && gitlabRepositoryURL === "")) {
       alert("不準啦馬的>///<")
     } else {
-      let payload = {
-        projectId: projectId,
-        repositoryURL: repositoryURL
+
+      if (githubRepositoryURL !== "") {
+        checker.push(checkGithubRepositoryURL());
       }
-      Axios.post(`http://localhost:9100/pvs-api/project/${projectId}/repository/${repoType}`, payload,
-        {headers: {"Authorization": `${jwtToken}`}})
-        .then(() => {
-          reloadProjects()
-          handleClose()
-        })
-        .catch((e) => {
-          alert(e.response.status)
-          console.error(e)
-        })
+      if (gitlabRepositoryURL !== "") {
+        checker.push(checkGitlabRepositoryURL());
+      }
+      if (sonarRepositoryURL !== "") {
+        checker.push(checkSonarRepositoryURL());
+      }
+
+      Promise.all(checker)
+        .then((response) => {
+          if (response.includes(false) === false) {
+            let payload = {
+              projectId: projectId,
+              repositoryURL: repositoryURL,
+              githubRepositoryURL: githubRepositoryURL,
+              gitlabRepositoryURL: gitlabRepositoryURL,
+              sonarRepositoryURL: sonarRepositoryURL
+            }
+
+            Axios.post(`http://localhost:9100/pvs-api/project/${projectId}/repository/${repoType}`, payload,
+              {headers: {"Authorization": `${jwtToken}`}})
+              .then(() => {
+                reloadProjects()
+                handleClose()
+              })
+              .catch((e) => {
+                alert(e.response.status)
+                console.error(e)
+              })
+          }
+        }).catch((e) => {
+        alert(e.response.status)
+        console.error(e)
+      })
     }
   }
 
+  const checkGithubRepositoryURL = () => {
+    return Axios.get(`http://localhost:9100/pvs-api/repository/github/check?url=${githubRepositoryURL}`,
+      {headers: {"Authorization": `${jwtToken}`}})
+      .then(() => {
+        setIsGithubAvailable(true);
+        return true
+      })
+      .catch(() => {
+        alert("github error")
+        return false
+      })
+  }
+
+  const checkGitlabRepositoryURL = () => {
+    return Axios.get(`http://localhost:9100/pvs-api/repository/gitlab/check?url=${gitlabRepositoryURL}`,
+      {headers: {"Authorization": `${jwtToken}`}})
+      .then(() => {
+        setIsGitlabAvailable(true);
+        return true
+      })
+      .catch(() => {
+        alert("gitlab error")
+        return false
+      })
+  }
+
+  const checkSonarRepositoryURL = () => {
+    return Axios.get(`http://localhost:9100/pvs-api/repository/sonar/check?url=${sonarRepositoryURL}`,
+      {headers: {"Authorization": `${jwtToken}`}})
+      .then(() => {
+        setIsSonarAvailable(true);
+        return true
+      })
+      .catch((e) => {
+        alert("sonar error")
+        console.error(e)
+        return false
+      })
+  }
+
+  const onClick1 = () => {
+    setShowGithubDiv(true)
+    setShowGitlabDiv(false)
+    setShowSonarDiv(false)
+  }
+  const onClick2 = () => {
+    setShowSonarDiv(true)
+    setShowGithubDiv(false)
+    setShowGitlabDiv(false)
+  }
+  const onClick3 = () => {
+    setShowGitlabDiv(true)
+    setShowGithubDiv(false)
+    setShowSonarDiv(false)
+  }
+
+  const close = () => {
+    setShowGithubDiv(false)
+    setShowGitlabDiv(false)
+    setShowSonarDiv(false)
+    handleClose()
+  }
+
+  const add = () => {
+    setShowGithubDiv(false)
+    setShowGitlabDiv(false)
+    setShowSonarDiv(false)
+    addRepository()
+  }
+
+  const GithubDiv = () => (
+    <div id="githubDiv">
+        <TextField
+          margin="dense"
+          id="GithubRepositoryURL"
+          label="Github Repository URL"
+          type="text"
+          fullWidth
+          onChange={(e) => {
+            setGithubRepositoryURL(e.target.value)
+          }}
+          required
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SiGithub/>
+              </InputAdornment>
+            ),
+          }}
+        />
+    </div>
+  )
+
+  const GitlabDiv = () => (
+      <div id="gitlabDiv">
+          <TextField
+//             margin={{5}}
+//             sx={{ m: 1, width: '25ch' }}
+            id="GitlabUsername"
+            label="Gitlab Account Username"
+            type="text"
+            style={{width: 250}}
+//             variant="outlined"
+            required
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <RiAccountCircleFill />
+                </InputAdornment>
+              ),
+            }}
+          />
+          <TextField
+//             margin={{5}}
+//             sx={{ m: 1, width: '25ch' }}
+            id="GitlabPassword"
+            label="Gitlab Account Password"
+            type="password"
+            style={{width: 250}}
+//             variant="outlined"
+            required
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <RiAccountCircleFill />
+                </InputAdornment>
+              ),
+            }}
+          />
+          <TextField
+            margin="dense"
+            id="GitlabToken"
+            label="Gitlab Token"
+            type="text"
+            fullWidth
+            required
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <GiToken />
+                </InputAdornment>
+              ),
+            }}
+          />
+          <TextField
+            margin="dense"
+            id="GitlabRepositoryURL"
+            label="Gitlab Repository URL"
+            type="text"
+            fullWidth
+            onChange={(e) => {
+              setGitlabRepositoryURL(e.target.value)
+            }}
+            required
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SiGitlab/>
+                </InputAdornment>
+              ),
+            }}
+          />
+      </div>
+  )
+
+  const SonarDiv = () => (
+    <div id = "sonarDiv">
+        <TextField
+          margin="dense"
+          id="SonarRepositoryURL"
+          label="Sonar Repository URL"
+          type="text"
+          fullWidth
+          onChange={(e) => {
+            setSonarRepositoryURL(e.target.value)
+          }}
+          required
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SiSonarqube/>
+              </InputAdornment>
+            ),
+          }}
+        />
+    </div>
+  )
+
   useEffect(() => {
     setRepositoryURL("")
+    setGithubRepositoryURL("")
+    setGitlabRepositoryURL("")
+    setSonarRepositoryURL("")
   }, [open])
 
   return (
@@ -44,9 +274,7 @@ export default function AddRepositoryDialog({open, reloadProjects, handleClose, 
       <DialogTitle id="form-dialog-title">Add Repository</DialogTitle>
       <DialogContent>
         <DialogContentText>
-          {repoType === "github" ?
-            "To add a GitHub repository, please enter the repository URL here." :
-            "To add a SonarQube repository, please enter the repository URL here."}
+            To add a repository, please select a repository type and enter the repository URL.
         </DialogContentText>
         <TextField
           margin="dense"
@@ -58,12 +286,33 @@ export default function AddRepositoryDialog({open, reloadProjects, handleClose, 
             setRepositoryURL(e.target.value)
           }}
         />
+        <label htmlFor="githubURL" margin="normal">
+            <input type = "radio" id = "selectedGithub" name = "repoType" onClick={onClick1}/>
+            GitHub
+        </label>
+        <div>
+            {showGithubDiv ? <GithubDiv /> : null}
+        </div>
+        <label htmlFor="gitlabURL" margin="normal">
+            <input type = "radio" id = "selectedGitlab" name = "repoType" onClick={onClick3}/>
+            GitLab
+        </label>
+        <div>
+            {showGitlabDiv ? <GitlabDiv /> : null}
+        </div>
+        <label htmlFor="sonarqubeURL" margin="normal">
+            <input type = "radio" value = "selectedSonar" name = "repoType" onClick={onClick2}/>
+            SonarQube
+        </label>
+        <div>
+            {showSonarDiv ? <SonarDiv /> : null}
+        </div>
       </DialogContent>
       <DialogActions>
-        <Button onClick={handleClose} color="secondary">
+        <Button onClick={close} color="secondary">
           Cancel
         </Button>
-        <Button onClick={addRepository} color="primary" id="AddRepositoryBtn">
+        <Button onClick={add} color="primary" id="AddRepositoryBtn">
           Create
         </Button>
       </DialogActions>

--- a/src/App/component/AddRepositoryDialog.jsx
+++ b/src/App/component/AddRepositoryDialog.jsx
@@ -180,55 +180,6 @@ export default function AddRepositoryDialog({open, reloadProjects, handleClose, 
   const GitlabDiv = () => (
       <div id="gitlabDiv">
           <TextField
-//             margin={{5}}
-//             sx={{ m: 1, width: '25ch' }}
-            id="GitlabUsername"
-            label="Gitlab Account Username"
-            type="text"
-            style={{width: 250}}
-//             variant="outlined"
-            required
-            InputProps={{
-              startAdornment: (
-                <InputAdornment position="start">
-                  <RiAccountCircleFill />
-                </InputAdornment>
-              ),
-            }}
-          />
-          <TextField
-//             margin={{5}}
-//             sx={{ m: 1, width: '25ch' }}
-            id="GitlabPassword"
-            label="Gitlab Account Password"
-            type="password"
-            style={{width: 250}}
-//             variant="outlined"
-            required
-            InputProps={{
-              startAdornment: (
-                <InputAdornment position="start">
-                  <RiAccountCircleFill />
-                </InputAdornment>
-              ),
-            }}
-          />
-          <TextField
-            margin="dense"
-            id="GitlabToken"
-            label="Gitlab Token"
-            type="text"
-            fullWidth
-            required
-            InputProps={{
-              startAdornment: (
-                <InputAdornment position="start">
-                  <GiToken />
-                </InputAdornment>
-              ),
-            }}
-          />
-          <TextField
             margin="dense"
             id="GitlabRepositoryURL"
             label="Gitlab Repository URL"

--- a/src/App/component/AddRepositoryDialog.jsx
+++ b/src/App/component/AddRepositoryDialog.jsx
@@ -7,13 +7,18 @@ import {
   DialogContent,
   DialogContentText,
   DialogTitle,
-  TextField
+  TextField,
+  Radio,
+  RadioGroup,
+  FormControl,
+  FormLabel,
+  FormControlLabel
 } from '@material-ui/core'
 
 import InputAdornment from '@material-ui/core/InputAdornment';
 import {SiGithub, SiSonarqube, SiGitlab} from 'react-icons/si'
 
-export default function AddRepositoryDialog({open, reloadProjects, handleClose, projectId, addSonarAvailable}) {
+export default function AddRepositoryDialog({open, reloadProjects, handleClose, projectId}) {
   const [repositoryURL, setRepositoryURL] = useState("")
   const [repoType, setRepoType] = useState("")
   const [githubRepositoryURL, setGithubRepositoryURL] = useState("")
@@ -42,7 +47,6 @@ export default function AddRepositoryDialog({open, reloadProjects, handleClose, 
       }
       if (sonarRepositoryURL !== "") {
         checker.push(checkSonarRepositoryURL());
-        checker.push(checkAddSonarAvailable());
       }
 
       Promise.all(checker)
@@ -109,15 +113,6 @@ export default function AddRepositoryDialog({open, reloadProjects, handleClose, 
         console.error(e)
         return false
       })
-  }
-
-  const checkAddSonarAvailable = () => {
-    if (addSonarAvailable) {
-      return true
-    } else {
-      alert("To add a SonarQube repository, you should first add a Github / GitLab repository.")
-      return false
-    }
   }
 
   const onClick1 = () => {
@@ -240,27 +235,27 @@ export default function AddRepositoryDialog({open, reloadProjects, handleClose, 
         <DialogContentText>
             To add a repository, please select a repository type and enter the repository URL.
         </DialogContentText>
-        <label htmlFor="githubURL" margin="normal">
-            <input type = "radio" id = "selectedGithub" name = "repoType" onClick={onClick1}/>
-            GitHub
-        </label>
+
+        <FormControl component="fieldset">
+          <FormLabel component="legend" />
+          <RadioGroup row aria-label="repoType" name="row-radio-buttons-group">
+            <FormControlLabel value="gitlab" control={<Radio />} onClick={onClick1} label="GitHub" />
+            <FormControlLabel value="github" control={<Radio />} onClick={onClick3} label="GitLab" />
+            <FormControlLabel value="sonar" control={<Radio />} onClick={onClick2} label="SonarQube" />
+            <FormControlLabel
+              value="disabled"
+              disabled
+              control={<Radio />}
+              label="other"
+            />
+          </RadioGroup>
+        </FormControl>
         <div>
             {showGithubDiv ? <GithubDiv /> : null}
-        </div>
-        <label htmlFor="gitlabURL" margin="normal">
-            <input type = "radio" id = "selectedGitlab" name = "repoType" onClick={onClick3}/>
-            GitLab
-        </label>
-        <div>
             {showGitlabDiv ? <GitlabDiv /> : null}
-        </div>
-        <label htmlFor="sonarqubeURL" margin="normal">
-            <input type = "radio" value = "selectedSonar" name = "repoType" onClick={onClick2}/>
-            SonarQube
-        </label>
-        <div>
             {showSonarDiv ? <SonarDiv /> : null}
         </div>
+
       </DialogContent>
       <DialogActions>
         <Button onClick={close} color="secondary">

--- a/src/App/component/AddRepositoryDialog.jsx
+++ b/src/App/component/AddRepositoryDialog.jsx
@@ -15,7 +15,7 @@ import {SiGithub, SiSonarqube, SiGitlab} from 'react-icons/si'
 import {RiAccountCircleFill} from 'react-icons/ri'
 import {GiToken} from 'react-icons/gi'
 
-export default function AddRepositoryDialog({open, reloadProjects, handleClose, projectId}) {
+export default function AddRepositoryDialog({open, reloadProjects, handleClose, projectId, addSonarAvailable}) {
   const [repositoryURL, setRepositoryURL] = useState("")
   const [repoType, setRepoType] = useState("")
   const [githubRepositoryURL, setGithubRepositoryURL] = useState("")
@@ -44,6 +44,7 @@ export default function AddRepositoryDialog({open, reloadProjects, handleClose, 
       }
       if (sonarRepositoryURL !== "") {
         checker.push(checkSonarRepositoryURL());
+        checker.push(addSonarAvailable);
       }
 
       Promise.all(checker)
@@ -110,6 +111,15 @@ export default function AddRepositoryDialog({open, reloadProjects, handleClose, 
         console.error(e)
         return false
       })
+  }
+
+  const checkAddSonarAvailable = () => {
+    if (addSonarAvailable) {
+      return true
+    } else {
+      alert("To add a SonarQube repository, you should first add a Github / GitLab repository.")
+      return false
+    }
   }
 
   const onClick1 = () => {

--- a/src/App/component/AddRepositoryDialog.jsx
+++ b/src/App/component/AddRepositoryDialog.jsx
@@ -32,7 +32,7 @@ export default function AddRepositoryDialog({open, reloadProjects, handleClose, 
 
   const addRepository = () => {
     let checker = []
-    if (repositoryURL === "" && (githubRepositoryURL === "" && sonarRepositoryURL === "" && gitlabRepositoryURL === "")) {
+    if (githubRepositoryURL === "" && sonarRepositoryURL === "" && gitlabRepositoryURL === "") {
       alert("不準啦馬的>///<")
     } else {
 
@@ -281,16 +281,6 @@ export default function AddRepositoryDialog({open, reloadProjects, handleClose, 
         <DialogContentText>
             To add a repository, please select a repository type and enter the repository URL.
         </DialogContentText>
-        <TextField
-          margin="dense"
-          id="RepositoryURL"
-          label="Repository URL"
-          type="text"
-          fullWidth
-          onChange={(e) => {
-            setRepositoryURL(e.target.value)
-          }}
-        />
         <label htmlFor="githubURL" margin="normal">
             <input type = "radio" id = "selectedGithub" name = "repoType" onClick={onClick1}/>
             GitHub

--- a/src/App/component/AddRepositoryDialog.jsx
+++ b/src/App/component/AddRepositoryDialog.jsx
@@ -24,9 +24,6 @@ export default function AddRepositoryDialog({open, reloadProjects, handleClose, 
   const [githubRepositoryURL, setGithubRepositoryURL] = useState("")
   const [gitlabRepositoryURL, setGitlabRepositoryURL] = useState("")
   const [sonarRepositoryURL, setSonarRepositoryURL] = useState("")
-  const setIsGithubAvailable = useState(false)[1]
-  const setIsGitlabAvailable = useState(false)[1]
-  const setIsSonarAvailable = useState(false)[1]
   const jwtToken = localStorage.getItem("jwtToken")
 
   const [showGithubDiv, setShowGithubDiv] = useState(false)
@@ -79,7 +76,6 @@ export default function AddRepositoryDialog({open, reloadProjects, handleClose, 
     return Axios.get(`http://localhost:9100/pvs-api/repository/github/check?url=${githubRepositoryURL}`,
       {headers: {"Authorization": `${jwtToken}`}})
       .then(() => {
-        setIsGithubAvailable(true);
         return true
       })
       .catch(() => {
@@ -92,7 +88,6 @@ export default function AddRepositoryDialog({open, reloadProjects, handleClose, 
     return Axios.get(`http://localhost:9100/pvs-api/repository/gitlab/check?url=${gitlabRepositoryURL}`,
       {headers: {"Authorization": `${jwtToken}`}})
       .then(() => {
-        setIsGitlabAvailable(true);
         return true
       })
       .catch(() => {
@@ -105,7 +100,6 @@ export default function AddRepositoryDialog({open, reloadProjects, handleClose, 
     return Axios.get(`http://localhost:9100/pvs-api/repository/sonar/check?url=${sonarRepositoryURL}`,
       {headers: {"Authorization": `${jwtToken}`}})
       .then(() => {
-        setIsSonarAvailable(true);
         return true
       })
       .catch((e) => {

--- a/src/App/component/AddRepositoryDialog.jsx
+++ b/src/App/component/AddRepositoryDialog.jsx
@@ -19,39 +19,27 @@ import InputAdornment from '@material-ui/core/InputAdornment';
 import {SiGithub, SiSonarqube, SiGitlab} from 'react-icons/si'
 
 export default function AddRepositoryDialog({open, reloadProjects, handleClose, projectId}) {
+
   const [repositoryURL, setRepositoryURL] = useState("")
   const [repoType, setRepoType] = useState("")
-  const [githubRepositoryURL, setGithubRepositoryURL] = useState("")
-  const [gitlabRepositoryURL, setGitlabRepositoryURL] = useState("")
-  const [sonarRepositoryURL, setSonarRepositoryURL] = useState("")
   const jwtToken = localStorage.getItem("jwtToken")
 
-  const [showGithubDiv, setShowGithubDiv] = useState(false)
-  const [showGitlabDiv, setShowGitlabDiv] = useState(false)
-  const [showSonarDiv, setShowSonarDiv] = useState(false)
+  const [showDiv, setShowDiv] = useState(false)
 
   const addRepository = () => {
     let checker = []
-    if (githubRepositoryURL === "" && sonarRepositoryURL === "" && gitlabRepositoryURL === "") {
+    if (repositoryURL.trim() === "") {
       alert("不準啦馬的>///<")
     } else {
 
-      if (githubRepositoryURL !== "") {
-        checker.push(checkGithubRepositoryURL());
-      }
-      if (gitlabRepositoryURL !== "") {
-        checker.push(checkGitlabRepositoryURL());
-      }
-      if (sonarRepositoryURL !== "") {
-        checker.push(checkSonarRepositoryURL());
-      }
+      checker.push(checkRepositoryURL());
 
       Promise.all(checker)
         .then((response) => {
           if (response.includes(false) === false) {
             let payload = {
-              projectId: projectId,
-              repositoryURL: repositoryURL
+              projectId,
+              repositoryURL
             }
 
             Axios.post(`http://localhost:9100/pvs-api/project/${projectId}/repository/${repoType}`, payload,
@@ -72,32 +60,31 @@ export default function AddRepositoryDialog({open, reloadProjects, handleClose, 
     }
   }
 
-  const checkGithubRepositoryURL = () => {
-    return Axios.get(`http://localhost:9100/pvs-api/repository/github/check?url=${githubRepositoryURL}`,
-      {headers: {"Authorization": `${jwtToken}`}})
-      .then(() => {
-        return true
-      })
-      .catch(() => {
-        alert("github error")
-        return false
-      })
-  }
-
-  const checkGitlabRepositoryURL = () => {
-    return Axios.get(`http://localhost:9100/pvs-api/repository/gitlab/check?url=${gitlabRepositoryURL}`,
-      {headers: {"Authorization": `${jwtToken}`}})
-      .then(() => {
-        return true
-      })
-      .catch(() => {
-        alert("gitlab error")
-        return false
-      })
-  }
-
-  const checkSonarRepositoryURL = () => {
-    return Axios.get(`http://localhost:9100/pvs-api/repository/sonar/check?url=${sonarRepositoryURL}`,
+  const checkRepositoryURL = () => {
+    if (repoType === "github") {
+      return Axios.get(`http://localhost:9100/pvs-api/repository/github/check?url=${repositoryURL}`,
+        {headers: {"Authorization": `${jwtToken}`}})
+        .then(() => {
+          return true
+        })
+        .catch(() => {
+          alert("github error")
+          return false
+        })
+    }
+    if (repoType === "gitlab") {
+      return Axios.get(`http://localhost:9100/pvs-api/repository/gitlab/check?url=${repositoryURL}`,
+        {headers: {"Authorization": `${jwtToken}`}})
+        .then(() => {
+          return true
+        })
+        .catch(() => {
+          alert("gitlab error")
+          return false
+        })
+    }
+    if (repoType === "sonar") {
+      return Axios.get(`http://localhost:9100/pvs-api/repository/sonar/check?url=${repositoryURL}`,
       {headers: {"Authorization": `${jwtToken}`}})
       .then(() => {
         return true
@@ -107,48 +94,24 @@ export default function AddRepositoryDialog({open, reloadProjects, handleClose, 
         console.error(e)
         return false
       })
+    }
   }
 
-  const onClick1 = () => {
-    setShowGithubDiv(true)
-    setShowGitlabDiv(false)
-    setShowSonarDiv(false)
-  }
-  const onClick2 = () => {
-    setShowSonarDiv(true)
-    setShowGithubDiv(false)
-    setShowGitlabDiv(false)
-  }
-  const onClick3 = () => {
-    setShowGitlabDiv(true)
-    setShowGithubDiv(false)
-    setShowSonarDiv(false)
+  const selected = (e) => {
+    setRepoType(e.target.value)
+    setShowDiv(e.target.checked)
   }
 
-  const close = () => {
-    setShowGithubDiv(false)
-    setShowGitlabDiv(false)
-    setShowSonarDiv(false)
-    handleClose()
-  }
-
-  const add = () => {
-    setShowGithubDiv(false)
-    setShowGitlabDiv(false)
-    setShowSonarDiv(false)
-    addRepository()
-  }
-
-  const GithubDiv = () => (
-    <div id="githubDiv">
+  const InputDiv = () => {
+    return(
+      <div>
         <TextField
           margin="dense"
-          id="GithubRepositoryURL"
-          label="Github Repository URL"
+          id="RepositoryURL"
+          label="Repository URL"
           type="text"
           fullWidth
           onChange={(e) => {
-            setGithubRepositoryURL(e.target.value)
             setRepositoryURL(e.target.value)
             setRepoType("github")
           }}
@@ -156,70 +119,27 @@ export default function AddRepositoryDialog({open, reloadProjects, handleClose, 
           InputProps={{
             startAdornment: (
               <InputAdornment position="start">
-                <SiGithub/>
+                {repoType === "github" &&
+                <SiGithub />
+                }
+                {repoType === "gitlab" &&
+                <SiGitlab />
+                }
+                {repoType === "sonar" &&
+                <SiSonarqube />
+                }
               </InputAdornment>
             ),
           }}
         />
-    </div>
-  )
-
-  const GitlabDiv = () => (
-      <div id="gitlabDiv">
-          <TextField
-            margin="dense"
-            id="GitlabRepositoryURL"
-            label="Gitlab Repository URL"
-            type="text"
-            fullWidth
-            onChange={(e) => {
-              setGitlabRepositoryURL(e.target.value)
-              setRepositoryURL(e.target.value)
-              setRepoType("gitlab")
-            }}
-            required
-            InputProps={{
-              startAdornment: (
-                <InputAdornment position="start">
-                  <SiGitlab/>
-                </InputAdornment>
-              ),
-            }}
-          />
       </div>
-  )
-
-  const SonarDiv = () => (
-    <div id = "sonarDiv">
-        <TextField
-          margin="dense"
-          id="SonarRepositoryURL"
-          label="Sonar Repository URL"
-          type="text"
-          fullWidth
-          onChange={(e) => {
-            setSonarRepositoryURL(e.target.value)
-            setRepositoryURL(e.target.value)
-            setRepoType("sonar")
-          }}
-          required
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                <SiSonarqube/>
-              </InputAdornment>
-            ),
-          }}
-        />
-    </div>
-  )
+    )
+  }
 
   useEffect(() => {
     setRepositoryURL("")
     setRepoType("")
-    setGithubRepositoryURL("")
-    setGitlabRepositoryURL("")
-    setSonarRepositoryURL("")
+    setShowDiv(false)
   }, [open])
 
   return (
@@ -229,33 +149,29 @@ export default function AddRepositoryDialog({open, reloadProjects, handleClose, 
         <DialogContentText>
             To add a repository, please select a repository type and enter the repository URL.
         </DialogContentText>
-
         <FormControl component="fieldset">
           <FormLabel component="legend" />
-          <RadioGroup row aria-label="repoType" name="row-radio-buttons-group">
-            <FormControlLabel value="gitlab" control={<Radio />} onClick={onClick1} label="GitHub" />
-            <FormControlLabel value="github" control={<Radio />} onClick={onClick3} label="GitLab" />
-            <FormControlLabel value="sonar" control={<Radio />} onClick={onClick2} label="SonarQube" />
-            <FormControlLabel
-              value="disabled"
-              disabled
-              control={<Radio />}
-              label="other"
-            />
-          </RadioGroup>
+            <RadioGroup row aria-label="repositoryType" name="row-radio-buttons-group">
+              <FormControlLabel value="github" control={<Radio />} onChange={selected} label="GitHub" />
+              <FormControlLabel value="gitlab" control={<Radio />} onClick={selected} label="GitLab" />
+              <FormControlLabel value="sonar" control={<Radio />} onClick={selected} label="SonarQube" />
+              <FormControlLabel
+                value="disabled"
+                disabled
+                control={<Radio />}
+                label="other"
+              />
+            </RadioGroup>
         </FormControl>
         <div>
-            {showGithubDiv ? <GithubDiv /> : null}
-            {showGitlabDiv ? <GitlabDiv /> : null}
-            {showSonarDiv ? <SonarDiv /> : null}
+            {showDiv ? <InputDiv /> : null}
         </div>
-
       </DialogContent>
       <DialogActions>
-        <Button onClick={close} color="secondary">
+        <Button onClick={handleClose} color="secondary">
           Cancel
         </Button>
-        <Button onClick={add} color="primary" id="AddRepositoryBtn">
+        <Button onClick={addRepository} color="primary" id="AddRepositoryBtn">
           Create
         </Button>
       </DialogActions>

--- a/src/App/component/AddRepositoryDialog.jsx
+++ b/src/App/component/AddRepositoryDialog.jsx
@@ -15,8 +15,9 @@ import {SiGithub, SiSonarqube, SiGitlab} from 'react-icons/si'
 import {RiAccountCircleFill} from 'react-icons/ri'
 import {GiToken} from 'react-icons/gi'
 
-export default function AddRepositoryDialog({open, reloadProjects, handleClose, projectId, repoType}) {
+export default function AddRepositoryDialog({open, reloadProjects, handleClose, projectId}) {
   const [repositoryURL, setRepositoryURL] = useState("")
+  const [repoType, setRepoType] = useState("")
   const [githubRepositoryURL, setGithubRepositoryURL] = useState("")
   const [gitlabRepositoryURL, setGitlabRepositoryURL] = useState("")
   const [sonarRepositoryURL, setSonarRepositoryURL] = useState("")
@@ -50,10 +51,7 @@ export default function AddRepositoryDialog({open, reloadProjects, handleClose, 
           if (response.includes(false) === false) {
             let payload = {
               projectId: projectId,
-              repositoryURL: repositoryURL,
-              githubRepositoryURL: githubRepositoryURL,
-              gitlabRepositoryURL: gitlabRepositoryURL,
-              sonarRepositoryURL: sonarRepositoryURL
+              repositoryURL: repositoryURL
             }
 
             Axios.post(`http://localhost:9100/pvs-api/project/${projectId}/repository/${repoType}`, payload,
@@ -154,6 +152,8 @@ export default function AddRepositoryDialog({open, reloadProjects, handleClose, 
           fullWidth
           onChange={(e) => {
             setGithubRepositoryURL(e.target.value)
+            setRepositoryURL(e.target.value)
+            setRepoType("github")
           }}
           required
           InputProps={{
@@ -226,6 +226,8 @@ export default function AddRepositoryDialog({open, reloadProjects, handleClose, 
             fullWidth
             onChange={(e) => {
               setGitlabRepositoryURL(e.target.value)
+              setRepositoryURL(e.target.value)
+              setRepoType("gitlab")
             }}
             required
             InputProps={{
@@ -249,6 +251,8 @@ export default function AddRepositoryDialog({open, reloadProjects, handleClose, 
           fullWidth
           onChange={(e) => {
             setSonarRepositoryURL(e.target.value)
+            setRepositoryURL(e.target.value)
+            setRepoType("sonar")
           }}
           required
           InputProps={{
@@ -264,6 +268,7 @@ export default function AddRepositoryDialog({open, reloadProjects, handleClose, 
 
   useEffect(() => {
     setRepositoryURL("")
+    setRepoType("")
     setGithubRepositoryURL("")
     setGitlabRepositoryURL("")
     setSonarRepositoryURL("")

--- a/src/App/component/ProjectAvatar.jsx
+++ b/src/App/component/ProjectAvatar.jsx
@@ -113,7 +113,7 @@ function ProjectAvatar(props) {
         reloadProjects={props.reloadProjects}
         handleClose={() => setAddRepoDialogOpen(false)}
         projectId={props.project.projectId}
-        repoType={wantedRepoType}
+//         repoType={wantedRepoType}
       />
     </div>
   )

--- a/src/App/component/ProjectAvatar.jsx
+++ b/src/App/component/ProjectAvatar.jsx
@@ -3,6 +3,7 @@ import {useHistory} from 'react-router-dom'
 import {makeStyles} from '@material-ui/core/styles'
 import {Box, CardActionArea, Avatar, CardActions, IconButton} from '@material-ui/core'
 import GitHubIcon from '@material-ui/icons/GitHub';
+import FilterDramaIcon from '@material-ui/icons/FilterDrama';
 import GpsFixedIcon from '@material-ui/icons/GpsFixed';
 import AddIcon from '@material-ui/icons/Add';
 import AddRepositoryDialog from './AddRepositoryDialog';
@@ -36,23 +37,21 @@ function ProjectAvatar(props) {
 
 
   const [addRepoDialogOpen, setAddRepoDialogOpen] = useState(false)
-  const [wantedRepoType, setWantedRepoType] = useState("")
   const [hasGithubRepo, setHasGithubRepo] = useState(false)
+  const [hasGitlabRepo, setHasGitlabRepo] = useState(false)
   const [hasSonarRepo, setHasSonarRepo] = useState(false)
+  const [addSonarAvailable, setAddSonarAvailable] = useState(false) // 限制
 
   useEffect(() => {
     if (props.size === 'large') {
       const githubRepo = props.project.repositoryDTOList.find(x => x.type === "github")
+      const gitlabRepo = props.project.repositoryDTOList.find(x => x.type === "gitlab")
       const sonarRepo = props.project.repositoryDTOList.find(x => x.type === "sonar")
 
       setHasGithubRepo(githubRepo !== undefined)
+      setHasGitlabRepo(gitlabRepo !== undefined)
       setHasSonarRepo(sonarRepo !== undefined)
-
-      if (githubRepo !== undefined) {
-        setWantedRepoType("sonar")
-      } else if (sonarRepo !== undefined) {
-        setWantedRepoType("github")
-      }
+      setAddSonarAvailable(githubRepo !== undefined || gitlabRepo !== undefined) // 要先有 githubRepo 或 gitlabRepo 才能新增 sonarRepo
     }
   }, [props.project])
 
@@ -95,12 +94,17 @@ function ProjectAvatar(props) {
             <GitHubIcon/>
           </IconButton>
           }
+          {hasGitlabRepo &&
+          <IconButton aria-label="GitLab" onClick={goToCommit}>
+            <FilterDramaIcon/>
+          </IconButton>
+          }
           {hasSonarRepo &&
           <IconButton aria-label="SonarQube" onClick={goToCodeCoverage}>
             <GpsFixedIcon/>
           </IconButton>
           }
-          {(!hasGithubRepo || !hasSonarRepo) &&
+          {(!hasGithubRepo || !hasGitlabRepo || !hasSonarRepo) &&
           <IconButton aria-label="Add Repository" onClick={showAddRepoDialog}>
             <AddIcon/>
           </IconButton>
@@ -113,7 +117,7 @@ function ProjectAvatar(props) {
         reloadProjects={props.reloadProjects}
         handleClose={() => setAddRepoDialogOpen(false)}
         projectId={props.project.projectId}
-//         repoType={wantedRepoType}
+        addSonarAvailable={addSonarAvailable}
       />
     </div>
   )

--- a/src/App/component/ProjectAvatar.jsx
+++ b/src/App/component/ProjectAvatar.jsx
@@ -40,18 +40,16 @@ function ProjectAvatar(props) {
   const [hasGithubRepo, setHasGithubRepo] = useState(false)
   const [hasGitlabRepo, setHasGitlabRepo] = useState(false)
   const [hasSonarRepo, setHasSonarRepo] = useState(false)
-  const [addSonarAvailable, setAddSonarAvailable] = useState(false) // 限制
 
   useEffect(() => {
     if (props.size === 'large') {
-      const githubRepo = props.project.repositoryDTOList.find(x => x.type === "github")
-      const gitlabRepo = props.project.repositoryDTOList.find(x => x.type === "gitlab")
-      const sonarRepo = props.project.repositoryDTOList.find(x => x.type === "sonar")
+      const getGithubRepo = props.project.repositoryDTOList.find(x => x.type === "github")
+      const getGitlabRepo = props.project.repositoryDTOList.find(x => x.type === "gitlab")
+      const getSonarRepo = props.project.repositoryDTOList.find(x => x.type === "sonar")
 
-      setHasGithubRepo(githubRepo !== undefined)
-      setHasGitlabRepo(gitlabRepo !== undefined)
-      setHasSonarRepo(sonarRepo !== undefined)
-      setAddSonarAvailable(githubRepo !== undefined || gitlabRepo !== undefined) // 要先有 githubRepo 或 gitlabRepo 才能新增 sonarRepo
+      setHasGithubRepo(getGithubRepo !== undefined)
+      setHasGitlabRepo(getGitlabRepo !== undefined)
+      setHasSonarRepo(getSonarRepo !== undefined)
     }
   }, [props.project])
 
@@ -117,7 +115,6 @@ function ProjectAvatar(props) {
         reloadProjects={props.reloadProjects}
         handleClose={() => setAddRepoDialogOpen(false)}
         projectId={props.project.projectId}
-        addSonarAvailable={addSonarAvailable}
       />
     </div>
   )


### PR DESCRIPTION
- 增加 radio button
- 新增 SonarQube & Jenkins 必須先有 GitHub/GitLab repo
- 解除自動判定新增 repo 類別的機制

- ~~新增 SonarQube or Jenkins 時，選取同 project 內對應的 Github or Gitlab repo~~
- ~~新增 repo 時，同類型的 repo 可以有多個~~