### PR TITLE
Simplify Sidebar

### DIFF
--- a/src/App/component/AddRepositoryDialog.jsx
+++ b/src/App/component/AddRepositoryDialog.jsx
@@ -128,7 +128,6 @@ export default function AddRepositoryDialog({open, reloadProjects, handleClose, 
           fullWidth
           onChange={(e) => {
             setRepositoryURL(e.target.value)
-            setRepoType("github")
           }}
           required
           InputProps={{

--- a/src/App/component/Sidebar.jsx
+++ b/src/App/component/Sidebar.jsx
@@ -181,16 +181,16 @@ function Sidebar(prop) {
             </ListItemIcon>
             <ListItemText primary="Select"/>
           </ListItem>
+          <Divider/>
 
           {/* dashboard UI button */}
-          <Divider className={classes.divider}/>
           <ListItem button onClick={goToDashBoard}>
             <ListItemIcon>
               <RiDashboardFill size={30}/>
             </ListItemIcon>
             <ListItemText primary="DashBoard"/>
           </ListItem>
-          <Divider className={classes.divider}/>
+          <Divider/>
 
           {/* github metrics UI button */}
           {currentProject &&
@@ -205,14 +205,15 @@ function Sidebar(prop) {
               <ListItemText primary="GitHub"/>
               {githubMenuOpen ? <ExpandLess/> : <ExpandMore/>}
             </ListItem>
-
             <Divider/>
+
             <Collapse in={githubMenuOpen} timeout="auto" unmountOnExit>
               <List component="div" disablePadding className={classes.innerList}>
                 {smallListItem("Commits", IoGitCommitSharp, goToCommit)}
                 {smallListItem("Issues", GoIssueOpened, goToIssue)}
                 {smallListItem("Code Base", Code, goToCodeBase)}
               </List>
+              <Divider/>
             </Collapse>
           </div>
           }
@@ -228,16 +229,17 @@ function Sidebar(prop) {
                 <SiGitlab size={30}/>
               </ListItemIcon>
               <ListItemText primary="GitLab"/>
-                {gitlabMenuOpen ? <ExpandLess/> : <ExpandMore/>}
+              {gitlabMenuOpen ? <ExpandLess/> : <ExpandMore/>}
             </ListItem>
+            <Divider/>
 
-              <Divider/>
-              <Collapse in={gitlabMenuOpen} timeout="auto" unmountOnExit>
+            <Collapse in={gitlabMenuOpen} timeout="auto" unmountOnExit>
               <List component="div" disablePadding className={classes.innerList}>
                 {smallListItem("Commits", IoGitCommitSharp, goToCommit)}
                 {smallListItem("Issues", GoIssueOpened, goToIssue)}
                 {smallListItem("Code Base", Code, goToCodeBase)}
               </List>
+              <Divider/>
             </Collapse>
           </div>
           }
@@ -246,7 +248,6 @@ function Sidebar(prop) {
           {currentProject &&
           currentProject.repositoryDTOList.find(x => x.type === "sonar") &&
           <div>
-            <Divider className={classes.divider}/>
             <ListItem button onClick={() => {
               setSonarMenuOpen(!sonarMenuOpen)
             }}>
@@ -258,6 +259,7 @@ function Sidebar(prop) {
               {sonarMenuOpen ? <ExpandLess/> : <ExpandMore/>}
             </ListItem>
             <Divider/>
+
             <Collapse in={sonarMenuOpen} timeout="auto" unmountOnExit>
               <List component="div" disablePadding className={classes.innerList}>
                 {smallListItem("Code Coverage", GpsFixed, goToCodeCoverage)}
@@ -281,14 +283,15 @@ function Sidebar(prop) {
                 <SiTrello size={30}/>
               </ListItemIcon>
               <ListItemText primary="Trello"/>
-                {trelloMenuOpen ? <ExpandLess/> : <ExpandMore/>}
+              {trelloMenuOpen ? <ExpandLess/> : <ExpandMore/>}
             </ListItem>
-
             <Divider/>
+
             <Collapse in={trelloMenuOpen} timeout="auto" unmountOnExit>
               <List component="div" disablePadding className={classes.innerList}>
                 {smallListItem("board", IoGitCommitSharp, goToTrelloBoard)}
               </List>
+              <Divider/>
             </Collapse>
           </div>
           }

--- a/src/App/component/Sidebar.jsx
+++ b/src/App/component/Sidebar.jsx
@@ -159,6 +159,18 @@ function Sidebar(prop) {
   const [sonarMenuOpen, setSonarMenuOpen] = useState(true)
   const [trelloMenuOpen, setTrelloMenuOpen] = useState(true)
 
+  const titleListItem = (text, Icon, open, setOpen) => (
+    <ListItem button onClick={() => {
+      setOpen(!open)
+    }}>
+      <ListItemIcon>
+        <Icon size={30}/>
+      </ListItemIcon>
+      <ListItemText primary={text}/>
+      {open ? <ExpandLess/> : <ExpandMore/>}
+    </ListItem>
+  )
+
   const smallListItem = (text, Icon, onClick) => (
     <ListItem button onClick={onClick}>
       <ListItemIcon>
@@ -196,15 +208,7 @@ function Sidebar(prop) {
           {currentProject &&
           currentProject.repositoryDTOList.find(x => x.type === "github") &&
           <div>
-            <ListItem button onClick={() => {
-              setGithubMenuOpen(!githubMenuOpen)
-            }}>
-              <ListItemIcon>
-                <SiGithub size={30}/>
-              </ListItemIcon>
-              <ListItemText primary="GitHub"/>
-              {githubMenuOpen ? <ExpandLess/> : <ExpandMore/>}
-            </ListItem>
+            {titleListItem("GitHub", SiGithub, githubMenuOpen, setGithubMenuOpen)}
             <Divider/>
 
             <Collapse in={githubMenuOpen} timeout="auto" unmountOnExit>
@@ -222,15 +226,7 @@ function Sidebar(prop) {
           {currentProject &&
           currentProject.repositoryDTOList.find(x => x.type === "gitlab") &&
           <div>
-            <ListItem button onClick={() => {
-              setGitlabMenuOpen(!gitlabMenuOpen)
-            }}>
-              <ListItemIcon>
-                <SiGitlab size={30}/>
-              </ListItemIcon>
-              <ListItemText primary="GitLab"/>
-              {gitlabMenuOpen ? <ExpandLess/> : <ExpandMore/>}
-            </ListItem>
+            {titleListItem("GitLab", SiGitlab, gitlabMenuOpen, setGitlabMenuOpen)}
             <Divider/>
 
             <Collapse in={gitlabMenuOpen} timeout="auto" unmountOnExit>
@@ -248,16 +244,7 @@ function Sidebar(prop) {
           {currentProject &&
           currentProject.repositoryDTOList.find(x => x.type === "sonar") &&
           <div>
-            <ListItem button onClick={() => {
-              setSonarMenuOpen(!sonarMenuOpen)
-            }}>
-
-              <ListItemIcon>
-                <SiSonarqube size={30}/>
-              </ListItemIcon>
-              <ListItemText primary="SonarQube"/>
-              {sonarMenuOpen ? <ExpandLess/> : <ExpandMore/>}
-            </ListItem>
+            {titleListItem("SonarQube", SiSonarqube, sonarMenuOpen, setSonarMenuOpen)}
             <Divider/>
 
             <Collapse in={sonarMenuOpen} timeout="auto" unmountOnExit>
@@ -276,15 +263,7 @@ function Sidebar(prop) {
           {currentProject &&
           currentProject.repositoryDTOList.find(x => x.type === "trello") &&
           <div>
-            <ListItem button onClick={() => {
-              setTrelloMenuOpen(!trelloMenuOpen)
-            }}>
-              <ListItemIcon>
-                <SiTrello size={30}/>
-              </ListItemIcon>
-              <ListItemText primary="Trello"/>
-              {trelloMenuOpen ? <ExpandLess/> : <ExpandMore/>}
-            </ListItem>
+            {titleListItem("Trello", SiTrello, trelloMenuOpen, setTrelloMenuOpen)}
             <Divider/>
 
             <Collapse in={trelloMenuOpen} timeout="auto" unmountOnExit>

--- a/src/App/component/Sidebar.jsx
+++ b/src/App/component/Sidebar.jsx
@@ -159,6 +159,15 @@ function Sidebar(prop) {
   const [sonarMenuOpen, setSonarMenuOpen] = useState(true)
   const [trelloMenuOpen, setTrelloMenuOpen] = useState(true)
 
+  const smallListItem = (text, Icon, onClick) => (
+    <ListItem button onClick={onClick}>
+      <ListItemIcon>
+        <Icon size={24.5}/>
+      </ListItemIcon>
+      <ListItemText primary={text}/>
+    </ListItem>
+  )
+
   const list = () => (
     <div className={classes.list} role="presentation">
       <List className={classes.menuList} width="inher">
@@ -200,26 +209,9 @@ function Sidebar(prop) {
             <Divider/>
             <Collapse in={githubMenuOpen} timeout="auto" unmountOnExit>
               <List component="div" disablePadding className={classes.innerList}>
-                <ListItem button className={classes.nested} onClick={goToCommit}>
-                  <ListItemIcon>
-                    <IoGitCommitSharp size={24.5}/>
-                  </ListItemIcon>
-                  <ListItemText primary="Commits"/>
-                </ListItem>
-
-                <ListItem button className={classes.nested} onClick={goToIssue}>
-                  <ListItemIcon>
-                    <GoIssueOpened size={24.5}/>
-                  </ListItemIcon>
-                  <ListItemText primary="Issues"/>
-                </ListItem>
-
-                <ListItem button className={classes.nested} onClick={goToCodeBase}>
-                  <ListItemIcon>
-                    <Code/>
-                  </ListItemIcon>
-                  <ListItemText primary="Code Base"/>
-                </ListItem>
+                {smallListItem("Commits", IoGitCommitSharp, goToCommit)}
+                {smallListItem("Issues", GoIssueOpened, goToIssue)}
+                {smallListItem("Code Base", Code, goToCodeBase)}
               </List>
             </Collapse>
           </div>
@@ -237,31 +229,14 @@ function Sidebar(prop) {
               </ListItemIcon>
               <ListItemText primary="GitLab"/>
                 {gitlabMenuOpen ? <ExpandLess/> : <ExpandMore/>}
-              </ListItem>
+            </ListItem>
 
               <Divider/>
               <Collapse in={gitlabMenuOpen} timeout="auto" unmountOnExit>
               <List component="div" disablePadding className={classes.innerList}>
-                <ListItem button className={classes.nested} onClick={goToCommit}>
-                  <ListItemIcon>
-                    <IoGitCommitSharp size={24.5}/>
-                  </ListItemIcon>
-                  <ListItemText primary="Commits"/>
-                </ListItem>
-
-                <ListItem button className={classes.nested} onClick={goToIssue}>
-                  <ListItemIcon>
-                    <GoIssueOpened size={24.5}/>
-                  </ListItemIcon>
-                  <ListItemText primary="Issues"/>
-                </ListItem>
-
-                <ListItem button className={classes.nested} onClick={goToCodeBase}>
-                  <ListItemIcon>
-                    <Code/>
-                  </ListItemIcon>
-                  <ListItemText primary="Code Base"/>
-                </ListItem>
+                {smallListItem("Commits", IoGitCommitSharp, goToCommit)}
+                {smallListItem("Issues", GoIssueOpened, goToIssue)}
+                {smallListItem("Code Base", Code, goToCodeBase)}
               </List>
             </Collapse>
           </div>
@@ -285,33 +260,10 @@ function Sidebar(prop) {
             <Divider/>
             <Collapse in={sonarMenuOpen} timeout="auto" unmountOnExit>
               <List component="div" disablePadding className={classes.innerList}>
-                <ListItem button onClick={goToCodeCoverage}>
-                  <ListItemIcon>
-                    <GpsFixed/>
-                  </ListItemIcon>
-                  <ListItemText primary="Code Coverage"/>
-                </ListItem>
-
-                <ListItem button onClick={goToBug}>
-                  <ListItemIcon>
-                    <AiFillBug size={24.5}/>
-                  </ListItemIcon>
-                  <ListItemText primary="Bugs"/>
-                </ListItem>
-
-                <ListItem button onClick={goToCodeSmell}>
-                  <ListItemIcon>
-                    <IoNuclear size={24.5}/>
-                  </ListItemIcon>
-                  <ListItemText primary="Code Smells"/>
-                </ListItem>
-
-                <ListItem button onClick={goToDuplication}>
-                  <ListItemIcon>
-                    <HiDocumentDuplicate size={24.5}/>
-                  </ListItemIcon>
-                  <ListItemText primary="Duplications"/>
-                </ListItem>
+                {smallListItem("Code Coverage", GpsFixed, goToCodeCoverage)}
+                {smallListItem("Bugs", AiFillBug, goToBug)}
+                {smallListItem("Code Smells", IoNuclear, goToCodeSmell)}
+                {smallListItem("Duplications", HiDocumentDuplicate, goToDuplication)}
               </List>
               <Divider/>
             </Collapse>
@@ -335,14 +287,7 @@ function Sidebar(prop) {
             <Divider/>
             <Collapse in={trelloMenuOpen} timeout="auto" unmountOnExit>
               <List component="div" disablePadding className={classes.innerList}>
-
-                <ListItem button className={classes.nested} onClick={goToTrelloBoard}>
-                  <ListItemIcon>
-                    <IoGitCommitSharp size={24.5}/>
-                  </ListItemIcon>
-                  <ListItemText primary="board"/>
-                </ListItem>
-
+                {smallListItem("board", IoGitCommitSharp, goToTrelloBoard)}
               </List>
             </Collapse>
           </div>

--- a/src/App/component/Sidebar.jsx
+++ b/src/App/component/Sidebar.jsx
@@ -159,7 +159,7 @@ function Sidebar(prop) {
   const [sonarMenuOpen, setSonarMenuOpen] = useState(true)
   const [trelloMenuOpen, setTrelloMenuOpen] = useState(true)
 
-  const titleListItem = (text, Icon, open, setOpen) => (
+  const buildTitleListItem = (text, Icon, open, setOpen) => (
     <ListItem button onClick={() => {
       setOpen(!open)
     }}>
@@ -171,7 +171,7 @@ function Sidebar(prop) {
     </ListItem>
   )
 
-  const smallListItem = (text, Icon, onClick) => (
+  const buildSmallListItem = (text, Icon, onClick) => (
     <ListItem button onClick={onClick}>
       <ListItemIcon>
         <Icon size={24.5}/>
@@ -180,7 +180,7 @@ function Sidebar(prop) {
     </ListItem>
   )
 
-  const list = () => (
+  const buildSidebarList = () => (
     <div className={classes.list} role="presentation">
       <List className={classes.menuList} width="inher">
         {prop.currentProjectId !== 0 &&
@@ -208,14 +208,14 @@ function Sidebar(prop) {
           {currentProject &&
           currentProject.repositoryDTOList.find(x => x.type === "github") &&
           <div>
-            {titleListItem("GitHub", SiGithub, githubMenuOpen, setGithubMenuOpen)}
+            {buildTitleListItem("GitHub", SiGithub, githubMenuOpen, setGithubMenuOpen)}
             <Divider/>
 
             <Collapse in={githubMenuOpen} timeout="auto" unmountOnExit>
               <List component="div" disablePadding className={classes.innerList}>
-                {smallListItem("Commits", IoGitCommitSharp, goToCommit)}
-                {smallListItem("Issues", GoIssueOpened, goToIssue)}
-                {smallListItem("Code Base", Code, goToCodeBase)}
+                {buildSmallListItem("Commits", IoGitCommitSharp, goToCommit)}
+                {buildSmallListItem("Issues", GoIssueOpened, goToIssue)}
+                {buildSmallListItem("Code Base", Code, goToCodeBase)}
               </List>
               <Divider/>
             </Collapse>
@@ -226,14 +226,14 @@ function Sidebar(prop) {
           {currentProject &&
           currentProject.repositoryDTOList.find(x => x.type === "gitlab") &&
           <div>
-            {titleListItem("GitLab", SiGitlab, gitlabMenuOpen, setGitlabMenuOpen)}
+            {buildTitleListItem("GitLab", SiGitlab, gitlabMenuOpen, setGitlabMenuOpen)}
             <Divider/>
 
             <Collapse in={gitlabMenuOpen} timeout="auto" unmountOnExit>
               <List component="div" disablePadding className={classes.innerList}>
-                {smallListItem("Commits", IoGitCommitSharp, goToCommit)}
-                {smallListItem("Issues", GoIssueOpened, goToIssue)}
-                {smallListItem("Code Base", Code, goToCodeBase)}
+                {buildSmallListItem("Commits", IoGitCommitSharp, goToCommit)}
+                {buildSmallListItem("Issues", GoIssueOpened, goToIssue)}
+                {buildSmallListItem("Code Base", Code, goToCodeBase)}
               </List>
               <Divider/>
             </Collapse>
@@ -244,15 +244,15 @@ function Sidebar(prop) {
           {currentProject &&
           currentProject.repositoryDTOList.find(x => x.type === "sonar") &&
           <div>
-            {titleListItem("SonarQube", SiSonarqube, sonarMenuOpen, setSonarMenuOpen)}
+            {buildTitleListItem("SonarQube", SiSonarqube, sonarMenuOpen, setSonarMenuOpen)}
             <Divider/>
 
             <Collapse in={sonarMenuOpen} timeout="auto" unmountOnExit>
               <List component="div" disablePadding className={classes.innerList}>
-                {smallListItem("Code Coverage", GpsFixed, goToCodeCoverage)}
-                {smallListItem("Bugs", AiFillBug, goToBug)}
-                {smallListItem("Code Smells", IoNuclear, goToCodeSmell)}
-                {smallListItem("Duplications", HiDocumentDuplicate, goToDuplication)}
+                {buildSmallListItem("Code Coverage", GpsFixed, goToCodeCoverage)}
+                {buildSmallListItem("Bugs", AiFillBug, goToBug)}
+                {buildSmallListItem("Code Smells", IoNuclear, goToCodeSmell)}
+                {buildSmallListItem("Duplications", HiDocumentDuplicate, goToDuplication)}
               </List>
               <Divider/>
             </Collapse>
@@ -263,12 +263,12 @@ function Sidebar(prop) {
           {currentProject &&
           currentProject.repositoryDTOList.find(x => x.type === "trello") &&
           <div>
-            {titleListItem("Trello", SiTrello, trelloMenuOpen, setTrelloMenuOpen)}
+            {buildTitleListItem("Trello", SiTrello, trelloMenuOpen, setTrelloMenuOpen)}
             <Divider/>
 
             <Collapse in={trelloMenuOpen} timeout="auto" unmountOnExit>
               <List component="div" disablePadding className={classes.innerList}>
-                {smallListItem("board", IoGitCommitSharp, goToTrelloBoard)}
+                {buildSmallListItem("board", IoGitCommitSharp, goToTrelloBoard)}
               </List>
               <Divider/>
             </Collapse>
@@ -399,7 +399,7 @@ function Sidebar(prop) {
       >
         <div className={classes.drawerContent}/>
         <Divider/>
-        {list()}
+        {buildSidebarList()}
       </Drawer>
       <main className={classes.content}>
         <div className={classes.drawerContent}/>


### PR DESCRIPTION
## Description
There were two duplicate sections of Sidebar DOM, so I added two functions, `titleListItem()` and `smallListItem()`, to reduce the lines.
When testing, I found a bug that users could add only the github repo. Because fixing the bug needed to delete just one line, so I debugged it with this PR.

## Screenshots
The left sidebar is still the same.
![image](https://user-images.githubusercontent.com/72587013/147360228-fa9bbc0f-af12-44cf-b417-522a85a3fad5.png)
