### PR TITLE
Set GitHub & GitLab options disable when GitHub / GitLab repo exists

### DIFF
--- a/src/App/component/AddRepositoryDialog.jsx
+++ b/src/App/component/AddRepositoryDialog.jsx
@@ -18,7 +18,7 @@ import {
 import InputAdornment from '@material-ui/core/InputAdornment';
 import { SiGithub, SiSonarqube, SiGitlab, SiTrello } from 'react-icons/si'
 
-export default function AddRepositoryDialog({ open, reloadProjects, handleClose, projectId }) {
+export default function AddRepositoryDialog({ open, reloadProjects, handleClose, projectId, hasGitRepo }) {
 
   const [repositoryURL, setRepositoryURL] = useState("")
   const [repoType, setRepoType] = useState("")
@@ -163,9 +163,9 @@ export default function AddRepositoryDialog({ open, reloadProjects, handleClose,
         <FormControl component="fieldset">
           <FormLabel component="legend" />
           <RadioGroup row aria-label="repositoryType" name="row-radio-buttons-group">
-            <FormControlLabel value="github" control={<Radio />} onChange={selected} label="GitHub" />
-            <FormControlLabel value="gitlab" control={<Radio />} onChange={selected} label="GitLab" />
-            <FormControlLabel value="sonar" control={<Radio />} onChange={selected} label="SonarQube" />
+            <FormControlLabel value="github" disabled={hasGitRepo ? true : false} control={<Radio />} onChange={selected} label="GitHub" />
+            <FormControlLabel value="gitlab" disabled={hasGitRepo ? true : false} control={<Radio />} onChange={selected} label="GitLab" />
+            <FormControlLabel value="sonar"  control={<Radio />} onChange={selected} label="SonarQube" />
             <FormControlLabel value="trello" control={<Radio />} onChange={selected} label="Trello" />
             <FormControlLabel
               value="disabled"

--- a/src/App/component/AddRepositoryDialog.jsx
+++ b/src/App/component/AddRepositoryDialog.jsx
@@ -163,8 +163,8 @@ export default function AddRepositoryDialog({ open, reloadProjects, handleClose,
         <FormControl component="fieldset">
           <FormLabel component="legend" />
           <RadioGroup row aria-label="repositoryType" name="row-radio-buttons-group">
-            <FormControlLabel value="github" disabled={hasGitRepo ? true : false} control={<Radio />} onChange={selected} label="GitHub" />
-            <FormControlLabel value="gitlab" disabled={hasGitRepo ? true : false} control={<Radio />} onChange={selected} label="GitLab" />
+            <FormControlLabel value="github" disabled={hasGitRepo} control={<Radio />} onChange={selected} label="GitHub" />
+            <FormControlLabel value="gitlab" disabled={hasGitRepo} control={<Radio />} onChange={selected} label="GitLab" />
             <FormControlLabel value="sonar"  control={<Radio />} onChange={selected} label="SonarQube" />
             <FormControlLabel value="trello" control={<Radio />} onChange={selected} label="Trello" />
             <FormControlLabel

--- a/src/App/component/ProjectAvatar.jsx
+++ b/src/App/component/ProjectAvatar.jsx
@@ -174,7 +174,7 @@ function ProjectAvatar(props) {
           <IconButton aria-label="Add Repository" onClick={showAddRepoDialog}>
             <AddIcon/>
           </IconButton>
-          
+
         </CardActions>
         }
       </Box>
@@ -183,6 +183,7 @@ function ProjectAvatar(props) {
         reloadProjects={props.reloadProjects}
         handleClose={() => setAddRepoDialogOpen(false)}
         projectId={props.project.projectId}
+        hasGitRepo={hasGithubRepo || hasGitlabRepo}
       />
     </div>
   )


### PR DESCRIPTION
# Description

When there is already a GitHub or GitLab repo in the project, it's not able to add another GitHub neither GitLab repo.

# Screenshot

![option](https://user-images.githubusercontent.com/40756699/147670957-f7aaa8ab-44e6-4823-9462-9ad4abd39d5b.JPG)
