### PR TITLE
Add helper text in add repo dialog

### DIFF
--- a/src/App/component/AddRepositoryDialog.jsx
+++ b/src/App/component/AddRepositoryDialog.jsx
@@ -12,7 +12,8 @@ import {
   RadioGroup,
   FormControl,
   FormLabel,
-  FormControlLabel
+  FormControlLabel,
+  FormHelperText
 } from '@material-ui/core'
 
 import InputAdornment from '@material-ui/core/InputAdornment';
@@ -143,6 +144,20 @@ export default function AddRepositoryDialog({ open, reloadProjects, handleClose,
             ),
           }}
         />
+        <FormHelperText id="helper-text">
+          {repoType === "github" &&
+            <p>Ex: https://github.com/USER/REPO</p>
+          }
+          {repoType === "gitlab" &&
+            <p>Ex: https://gitlab.com/USER/REPO</p>
+          }
+          {repoType === "sonar" &&
+            <p>Ex: https://sonarcloud.io/project/overview?id=ID</p>
+          }
+          {repoType === "trello" &&
+            <p>Ex: https://trello.com/b/abcdef/BOARD_NAME</p>
+          }
+        </FormHelperText>
       </div>
     )
   }

--- a/src/App/component/AddRepositoryDialog.jsx
+++ b/src/App/component/AddRepositoryDialog.jsx
@@ -18,7 +18,7 @@ import {
 import InputAdornment from '@material-ui/core/InputAdornment';
 import { SiGithub, SiSonarqube, SiGitlab, SiTrello } from 'react-icons/si'
 
-export default function AddRepositoryDialog({ open, reloadProjects, handleClose, projectId }) {
+export default function AddRepositoryDialog({ open, reloadProjects, handleClose, projectId, hasGitRepo }) {
 
   const [repositoryURL, setRepositoryURL] = useState("")
   const [repoType, setRepoType] = useState("")
@@ -163,9 +163,9 @@ export default function AddRepositoryDialog({ open, reloadProjects, handleClose,
         <FormControl component="fieldset">
           <FormLabel component="legend" />
           <RadioGroup row aria-label="repositoryType" name="row-radio-buttons-group">
-            <FormControlLabel value="github" control={<Radio />} onChange={selected} label="GitHub" />
-            <FormControlLabel value="gitlab" control={<Radio />} onChange={selected} label="GitLab" />
-            <FormControlLabel value="sonar" control={<Radio />} onChange={selected} label="SonarQube" />
+            <FormControlLabel value="github" disabled={hasGitRepo ? true : false} control={<Radio />} onChange={selected} label="GitHub" />
+            <FormControlLabel value="gitlab" disabled={hasGitRepo ? true : false} control={<Radio />} onChange={selected} label="GitLab" />
+            <FormControlLabel value="sonar"  control={<Radio />} onChange={selected} label="SonarQube" />
             <FormControlLabel value="trello" control={<Radio />} onChange={selected} label="Trello" />
             <FormControlLabel
               value="disabled"

--- a/src/App/component/AddRepositoryDialog.jsx
+++ b/src/App/component/AddRepositoryDialog.jsx
@@ -163,8 +163,8 @@ export default function AddRepositoryDialog({ open, reloadProjects, handleClose,
         <FormControl component="fieldset">
           <FormLabel component="legend" />
           <RadioGroup row aria-label="repositoryType" name="row-radio-buttons-group">
-            <FormControlLabel value="github" disabled={hasGitRepo ? true : false} control={<Radio />} onChange={selected} label="GitHub" />
-            <FormControlLabel value="gitlab" disabled={hasGitRepo ? true : false} control={<Radio />} onChange={selected} label="GitLab" />
+            <FormControlLabel value="github" disabled={hasGitRepo} control={<Radio />} onChange={selected} label="GitHub" />
+            <FormControlLabel value="gitlab" disabled={hasGitRepo} control={<Radio />} onChange={selected} label="GitLab" />
             <FormControlLabel value="sonar"  control={<Radio />} onChange={selected} label="SonarQube" />
             <FormControlLabel value="trello" control={<Radio />} onChange={selected} label="Trello" />
             <FormControlLabel

--- a/src/App/component/ProjectAvatar.jsx
+++ b/src/App/component/ProjectAvatar.jsx
@@ -174,7 +174,7 @@ function ProjectAvatar(props) {
           <IconButton aria-label="Add Repository" onClick={showAddRepoDialog}>
             <AddIcon/>
           </IconButton>
-          
+
         </CardActions>
         }
       </Box>
@@ -183,6 +183,7 @@ function ProjectAvatar(props) {
         reloadProjects={props.reloadProjects}
         handleClose={() => setAddRepoDialogOpen(false)}
         projectId={props.project.projectId}
+        hasGitRepo={hasGithubRepo || hasGitlabRepo}
       />
     </div>
   )


### PR DESCRIPTION
# Description

To avoid user entering wrong repository URL, there is an example URL below the text field.

# Screenshot
![helper_github](https://user-images.githubusercontent.com/40756699/147872710-3cb2a183-8558-45ee-944b-cf16d2cbc052.jpg)
![helper_gitlab](https://user-images.githubusercontent.com/40756699/147872713-08f6685d-5dca-4486-9272-5f05704fff97.jpg)
![helper_sonar](https://user-images.githubusercontent.com/40756699/147872717-b86497d4-1553-4811-998e-5ad1e549916d.jpg)
![helper_trello](https://user-images.githubusercontent.com/40756699/147872721-f12067e6-f2f8-43e6-b504-487f4896f4e3.jpg)


